### PR TITLE
Add core models to fix UI import error

### DIFF
--- a/src/dndcs/core/__init__.py
+++ b/src/dndcs/core/__init__.py
@@ -1,0 +1,4 @@
+from . import registry, models
+from .module_base import ModuleBase
+
+__all__ = ["ModuleBase", "registry", "models"]

--- a/src/dndcs/core/models.py
+++ b/src/dndcs/core/models.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
+
+class AbilityScore(BaseModel):
+    name: str
+    score: int
+
+class Skill(BaseModel):
+    name: str
+    ability: str
+
+class Item(BaseModel):
+    name: str
+    quantity: int = 1
+    props: Dict[str, Any] = Field(default_factory=dict)
+
+class Feat(BaseModel):
+    name: str
+    props: Dict[str, Any] = Field(default_factory=dict)
+
+class Proficiencies(BaseModel):
+    saving_throws: Dict[str, bool] = Field(default_factory=dict)
+
+class Character(BaseModel):
+    name: str
+    level: int
+    module: str
+    abilities: Dict[str, AbilityScore] = Field(default_factory=dict)
+    skills: List[Skill] = Field(default_factory=list)
+    items: List[Item] = Field(default_factory=list)
+    feats: List[Feat] = Field(default_factory=list)
+    notes: Optional[str] = None
+    proficiencies: Proficiencies = Field(default_factory=Proficiencies)


### PR DESCRIPTION
## Summary
- define core data models (AbilityScore, Skill, Item, etc.) with Pydantic
- expose core modules via `dndcs.core` package init

## Testing
- `python -m pip install -e ".[ui]"`
- `pytest`
- `ruff check src/dndcs/core/models.py src/dndcs/core/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68aca81b08188330a321229adbc20c80