### PR TITLE
feat: extend character model

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,19 @@ dndcs ui
 The server listens on `http://127.0.0.1:8000` by default and opens in your browser. Use `--host`, `--port` and `--no-open` to control the startup behaviour.
 
 Rules modules are discovered automatically. Drop a module directory containing a `manifest.yaml` and a main file into `mods/` or `modules/` to extend the rules.  The manifest can declare a `subsystems` list so Python files placed in those named subfolders (for example `items/`, `feats` or `spells`) are pulled in automatically.  See `src/dndcs/modules/fivee_stock` for a built-in 5e implementation example.
+
+## Character Model
+
+The `dndcs.core.models.Character` schema contains the core data for a character. In addition to baseline fields such as `name`, `level`, and `module`, the model also supports:
+
+- `class` – character class
+- `subclass` – optional subclass or archetype
+- `race` – character race
+- `background` – starting background
+- `alignment` – moral alignment
+- `hit_points` – current hit point total
+- `hit_dice` – hit dice expression (e.g. `"1d8"`)
+- `spellcasting` – spellcasting data, free-form and module defined
+- `companions` – list of companion characters
+
+All of these fields are optional and default to empty or `None` so existing code that constructs a `Character` without them continues to work.

--- a/src/dndcs/core/models.py
+++ b/src/dndcs/core/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from typing import Any, Dict, List, Optional
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 
 class AbilityScore(BaseModel):
     name: str
@@ -23,12 +23,23 @@ class Proficiencies(BaseModel):
     saving_throws: Dict[str, bool] = Field(default_factory=dict)
 
 class Character(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     name: str
     level: int
     module: str
+    class_: Optional[str] = Field(default=None, alias="class")
+    subclass: Optional[str] = None
+    race: Optional[str] = None
+    background: Optional[str] = None
+    alignment: Optional[str] = None
+    hit_points: Optional[int] = None
+    hit_dice: Optional[str] = None
     abilities: Dict[str, AbilityScore] = Field(default_factory=dict)
     skills: List[Skill] = Field(default_factory=list)
     items: List[Item] = Field(default_factory=list)
     feats: List[Feat] = Field(default_factory=list)
     notes: Optional[str] = None
     proficiencies: Proficiencies = Field(default_factory=Proficiencies)
+    spellcasting: Dict[str, Any] = Field(default_factory=dict)
+    companions: List['Character'] = Field(default_factory=list)

--- a/src/dndcs/ui/server.py
+++ b/src/dndcs/ui/server.py
@@ -90,7 +90,7 @@ def create_app() -> FastAPI:
             items=[],
             feats=[],
         )
-        return JSONResponse(char.model_dump())
+        return JSONResponse(char.model_dump(by_alias=True, exclude_none=True))
 
     @app.post("/api/derive")
     async def api_derive(req: Request):


### PR DESCRIPTION
## Summary
- extend `Character` schema with class, race, background, alignment and combat fields
- adjust API serialization to expose new fields with aliases
- document new `Character` fields in README

## Testing
- `python -m pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad431382748330b6129efa4c419057