### PR TITLE
Add companion support to FiveE module

### DIFF
--- a/src/dndcs/core/models.py
+++ b/src/dndcs/core/models.py
@@ -22,6 +22,16 @@ class Feat(BaseModel):
 class Proficiencies(BaseModel):
     saving_throws: Dict[str, bool] = Field(default_factory=dict)
 
+
+class Companion(BaseModel):
+    """Lightweight character-like creature that assists the main character."""
+
+    name: str
+    template: Optional[str] = None
+    abilities: Dict[str, AbilityScore] = Field(default_factory=dict)
+    bonuses: Dict[str, Any] = Field(default_factory=dict)
+    notes: Optional[str] = None
+
 class Character(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
@@ -42,4 +52,4 @@ class Character(BaseModel):
     notes: Optional[str] = None
     proficiencies: Proficiencies = Field(default_factory=Proficiencies)
     spellcasting: Dict[str, Any] = Field(default_factory=dict)
-    companions: List['Character'] = Field(default_factory=list)
+    companions: List[Companion] = Field(default_factory=list)

--- a/src/dndcs/modules/fivee_stock/companions/basic.py
+++ b/src/dndcs/modules/fivee_stock/companions/basic.py
@@ -1,0 +1,29 @@
+"""Default companion templates for the stock 5e module.
+
+This intentionally only covers a handful of common options used in tests.
+"""
+
+COMPANIONS = {
+    # A simple owl familiar from the Find Familiar spell.
+    "owl": {
+        "abilities": {"STR": 3, "DEX": 15, "CON": 8, "INT": 2, "WIS": 12, "CHA": 7},
+        "ac": 11,
+        "hit_points": 1,
+        # help_action allows the companion to use the Help action in combat.
+        # shared_senses represents the familiar's ability to share senses with the
+        # summoner as per the Find Familiar spell.
+        "bonuses": {
+            "help_action": True,
+            "shared_senses": ["darkvision", "hearing", "sight"],
+        },
+    },
+    # A basic wolf used by the ranger's Beast Master archetype.
+    "wolf": {
+        "abilities": {"STR": 12, "DEX": 15, "CON": 12, "INT": 3, "WIS": 12, "CHA": 6},
+        "ac": 13,
+        "hit_points": 11,
+        "bonuses": {
+            "help_action": True,
+        },
+    },
+}

--- a/src/dndcs/modules/fivee_stock/manifest.yaml
+++ b/src/dndcs/modules/fivee_stock/manifest.yaml
@@ -8,3 +8,4 @@ subsystems:
   - feats
   - spells
   - classes
+  - companions

--- a/tests/test_companions.py
+++ b/tests/test_companions.py
@@ -1,0 +1,25 @@
+from dndcs.core import models
+from dndcs.modules.fivee_stock.module import FiveEStockModule
+
+
+def _abilities(**scores):
+    abils = {}
+    for name in ("STR","DEX","CON","INT","WIS","CHA"):
+        abils[name] = models.AbilityScore(name=name, score=scores.get(name,10))
+    return abils
+
+
+def test_familiar_help_and_senses():
+    mod = FiveEStockModule({"id": "fivee_stock"})
+    char = models.Character(
+        name="Mage",
+        level=1,
+        module="fivee_stock",
+        abilities=_abilities(),
+        companions=[models.Companion(name="Owl", template="owl")],
+    )
+    out = mod.derive(char)
+    assert out["bonuses"]["help_action"] is True
+    assert "darkvision" in out["bonuses"]["shared_senses"]
+    comp = out["companions"][0]
+    assert comp["ability_mods"]["DEX"] == 2


### PR DESCRIPTION
## Summary
- add Companion model and companions field on Character
- supply basic companion templates (owl, wolf)
- compute companion bonuses in FiveEStockModule

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad5b606d6c8330a0b12be0a80286cc