### PR TITLE
Add UI test for level 17 wizard and fix module loading

### DIFF
--- a/src/dndcs/core/module_base.py
+++ b/src/dndcs/core/module_base.py
@@ -23,6 +23,8 @@ class ModuleBase:
                 continue
             loaded: List[ModuleType] = []
             for py in sect_dir.glob("*.py"):
+                if py.name == "__init__.py":
+                    continue
                 spec = importlib.util.spec_from_file_location(
                     f"dndcs_mod_{manifest.get('id','mod')}_{sect}_{py.stem}", py
                 )

--- a/src/dndcs/modules/fivee_stock/module.py
+++ b/src/dndcs/modules/fivee_stock/module.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from math import floor
 from dndcs.core import models
 from dndcs.core.module_base import ModuleBase
-from .classes import CLASSES
+from dndcs.modules.fivee_stock.classes import CLASSES
 
 ABILS = ("STR","DEX","CON","INT","WIS","CHA")
 SKILLS = [

--- a/tests/data/wizard_l17.json
+++ b/tests/data/wizard_l17.json
@@ -1,0 +1,38 @@
+{
+  "name": "Test Wizard",
+  "level": 17,
+  "module": "fivee_stock",
+  "class": "wizard",
+  "race": "Tiefling",
+  "abilities": {
+    "STR": {"name": "STR", "score": 8},
+    "DEX": {"name": "DEX", "score": 14},
+    "CON": {"name": "CON", "score": 14},
+    "INT": {"name": "INT", "score": 20},
+    "WIS": {"name": "WIS", "score": 16},
+    "CHA": {"name": "CHA", "score": 10}
+  },
+  "items": [
+    {
+      "name": "Spellbook",
+      "props": {
+        "spellbook": {
+          "prepared": {
+            "1": ["mage armor", "magic missile", "shield"],
+            "2": ["mirror image", "misty step"],
+            "3": ["counterspell", "fireball", "fly"],
+            "4": ["dimension door", "ice storm"],
+            "5": ["wall of force", "teleportation circle"],
+            "6": ["globe of invulnerability"],
+            "7": ["plane shift"],
+            "8": ["maze", "mind blank"],
+            "9": ["wish"]
+          }
+        }
+      }
+    },
+    {"name": "Quarterstaff"},
+    {"name": "Robe of the Archmagi", "props": {"ac_base": 15}}
+  ],
+  "notes": "Level 17 test wizard with assorted spells and items"
+}

--- a/tests/test_ui_character.py
+++ b/tests/test_ui_character.py
@@ -1,0 +1,27 @@
+import json
+from pathlib import Path
+from fastapi.testclient import TestClient
+from dndcs.ui.server import create_app
+
+
+def _load_test_character() -> dict:
+    path = Path(__file__).parent / "data" / "wizard_l17.json"
+    return json.loads(path.read_text())
+
+
+def test_ui_can_derive_level17_wizard():
+    app = create_app()
+    client = TestClient(app)
+    payload = _load_test_character()
+    resp = client.post("/api/derive", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "spellcasting" in data
+    slots = data["spellcasting"]["slots"]
+    assert slots["1"] == 4
+    assert slots["9"] == 1
+    block = data["spellcasting"]["classes"][0]
+    assert block["class"] == "wizard"
+    assert block["spell_save_dc"] == 19
+    assert block["prepared_max"] == 22
+    assert "wish" in block["prepared_spells"]


### PR DESCRIPTION
## Summary
- add sample level 17 wizard character with spells and items
- test FastAPI UI derivation for the character
- fix module loading by skipping `__init__.py` and using absolute imports

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad63fd3ed88330a127e2c47e742ab2