### PR TITLE
Add install and run batch scripts for integrated UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,30 @@
 # DnDCS
 
-Modular backend for Dungeons & Dragons character sheets with an optional web UI.
+Modular backend for Dungeons & Dragons character sheets with an integrated web UI.
 
 ## Features
 - Discoverable rules modules loaded from `mods/`, `modules/` or a user config directory.
 - Command line interface `dndcs` with a subcommand to launch a local web interface.
 
 ## Installation
-Requires **Python 3.10+**. Clone the repository and install with pip:
+Requires **Python 3.10+**. Clone the repository and install with the included script:
 
-```bash
+```cmd
 git clone https://github.com/FireDragonSlayer-0001/DnDCS
 cd DnDCS
-python -m pip install -e .
-```
-
-To include the optional web UI dependencies:
-
-```bash
-python -m pip install -e .[ui]
+install.bat
 ```
 
 ## Usage
 Start the web interface:
 
-```bash
-dndcs ui
+```cmd
+run.bat
 ```
 
 The server listens on `http://127.0.0.1:8000` by default and opens in your browser. Use `--host`, `--port` and `--no-open` to control the startup behaviour.
 
-Rules modules are discovered automatically. Drop a module directory containing a `manifest.yaml` and a main file into `mods/` or `modules/` to extend the rules.  The manifest can declare a `subsystems` list so Python files placed in those named subfolders (for example `items/`, `feats` or `spells`) are pulled in automatically.  See `src/dndcs/modules/fivee_stock` for a built-in 5e implementation example.
+Rules modules are discovered automatically. Drop a module directory containing a `manifest.yaml` and a main file into `mods/` or `modules/` to extend the rules. The manifest can declare a `subsystems` list so Python files placed in those named subfolders (for example `items/`, `feats` or `spells`) are pulled in automatically. See `src/dndcs/modules/fivee_stock` for a built-in 5e implementation example.
 
 ## Character Model
 

--- a/install.bat
+++ b/install.bat
@@ -1,0 +1,3 @@
+@echo off
+REM Install DnDCS with UI dependencies.
+python -m pip install -e ".[ui]"

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,3 @@
+@echo off
+REM Launch the DnDCS web UI in your browser.
+python -m dndcs.cli ui %*


### PR DESCRIPTION
## Summary
- Replace `install.sh` and `run.sh` with `install.bat` and `run.bat` for Windows environments
- Update README to reference the `.bat` scripts for installation and running the web UI

## Testing
- `python -m pip install -e ".[ui]"`
- `python -m pip install httpx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad659c05388330b3f32d34f22ca2a6