### PR TITLE
Ensure run scripts launch web UI

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -1,3 +1,8 @@
 @echo off
+setlocal
+cd /d "%~dp0"
+REM Ensure local src package is on PYTHONPATH so the app can run without installation
+set "PYTHONPATH=%CD%\src;%PYTHONPATH%"
 REM Launch the DnDCS web UI in your browser.
-python -m dndcs.cli ui %*
+python -m dndcs.cli ui %* || pause
+endlocal

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 # Launch the DnDCS web UI in your browser.
+# Ensure local src package is on PYTHONPATH so the app can run without installation
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export PYTHONPATH="$SCRIPT_DIR/src:${PYTHONPATH}"
 python -m dndcs.cli ui "$@"

--- a/src/dndcs/cli.py
+++ b/src/dndcs/cli.py
@@ -63,3 +63,7 @@ def search_spells(name: str | None, cls: str | None):
     results = search(name=name, cls=cls)
     for sp in sorted(results, key=lambda s: (s["level"], s["name"])):
         click.echo(f"{sp['name']} (Level {sp['level']} {sp['school']})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python path setup to Windows and Unix launch scripts so the web UI runs without installation
- execute CLI entrypoint when run as a module

## Testing
- `pip install -e .[ui]`
- `pip install httpx`
- `pytest`
- `python -m dndcs.cli ui --no-open`

------
https://chatgpt.com/codex/tasks/task_e_68ad6b4301b08330a2b78b5980da1476