### PR TITLE
feat: add central logging system

### DIFF
--- a/src/dndcs/cli.py
+++ b/src/dndcs/cli.py
@@ -1,10 +1,14 @@
 import json
 import click
 
+from dndcs.logger import init_logging
+
 @click.group()
 def main():
     """DnDCS CLI."""
-    pass
+    # Configure logging so each run produces a log file and warnings/errors
+    # are echoed to the terminal for easier debugging.
+    init_logging()
 
 @main.command("ui")
 @click.option("--host", default="127.0.0.1", show_default=True)

--- a/src/dndcs/logger.py
+++ b/src/dndcs/logger.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from datetime import datetime
+from typing import Optional
+
+_LOG_FILE: Optional[Path] = None
+
+def init_logging(log_dir: str | Path = "logs", console_level: int = logging.WARNING) -> Path:
+    """Initialize application-wide logging.
+
+    Creates a timestamped log file in ``log_dir`` and attaches handlers
+    to the ``dndcs`` root logger. Further calls are ignored and simply
+    return the path to the previously created log file.
+    """
+    global _LOG_FILE
+    if _LOG_FILE is not None:
+        return _LOG_FILE
+
+    log_path = Path(log_dir)
+    log_path.mkdir(parents=True, exist_ok=True)
+    _LOG_FILE = log_path / f"dndcs_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
+
+    logger = logging.getLogger("dndcs")
+    logger.setLevel(logging.DEBUG)
+
+    file_handler = logging.FileHandler(_LOG_FILE, encoding="utf-8")
+    file_handler.setLevel(logging.DEBUG)
+    fmt = logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+    file_handler.setFormatter(fmt)
+    logger.addHandler(file_handler)
+
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(console_level)
+    console_handler.setFormatter(fmt)
+    logger.addHandler(console_handler)
+
+    logging.captureWarnings(True)
+    return _LOG_FILE
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a logger namespaced under ``dndcs``."""
+    return logging.getLogger(f"dndcs.{name}")

--- a/src/dndcs/ui/server.py
+++ b/src/dndcs/ui/server.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from pathlib import Path
-import os, threading, time, webbrowser, logging
+import os, threading, time, webbrowser
 from typing import Dict, Any
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import FileResponse, JSONResponse
@@ -8,9 +8,9 @@ from fastapi.staticfiles import StaticFiles
 import uvicorn
 
 from dndcs.core import models, registry, discovery, loader
+from dndcs.logger import get_logger, init_logging
 
-log = logging.getLogger("dndcs.ui")
-logging.basicConfig(level=logging.INFO)
+log = get_logger("ui")
 
 
 def _static_dir() -> Path:
@@ -141,6 +141,8 @@ def create_app() -> FastAPI:
 
 
 def serve(host: str = "127.0.0.1", port: int = 8000, open_browser: bool = True) -> None:
+    # Ensure logging is configured for UI runs.
+    init_logging()
     app = create_app()
     if open_browser:
         def _open():


### PR DESCRIPTION
## Summary
- add logger module that writes logs to file and prints warnings/errors to console
- wire logging into CLI and UI server

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad6e2d92888330a010684ef0c3cc7b