### PR TITLE
Capture UI errors in server logs

### DIFF
--- a/src/dndcs/ui/server.py
+++ b/src/dndcs/ui/server.py
@@ -85,6 +85,19 @@ def create_app() -> FastAPI:
         spells = spell_search(name=name, cls=cls)
         return {"spells": spells}
 
+    @app.post("/api/log")
+    async def api_log(req: Request):
+        data = await req.json()
+        level = (data.get("level") or "info").lower()
+        message = data.get("message") or ""
+        stack = data.get("stack")
+        log_fn = getattr(log, level if level in {"debug", "info", "warning", "error", "critical"} else "info")
+        if stack:
+            log_fn("UI: %s\n%s", message, stack)
+        else:
+            log_fn("UI: %s", message)
+        return {"ok": True}
+
     @app.get("/mods/{module_id}/assets/{path:path}")
     def serve_asset(module_id: str, path: str):
         for man in discovery.discover_modules():


### PR DESCRIPTION
## Summary
- add `/api/log` endpoint to write client-side error reports to the server log
- send UI exceptions to the backend via a new `logError` helper
- log issues during module load, character creation, and file opening

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad7303cd4c8330bf4875091faa6e82