### PR TITLE
Handle empty default module env var

### DIFF
--- a/src/dndcs/core/registry.py
+++ b/src/dndcs/core/registry.py
@@ -8,6 +8,10 @@ def default_module_id() -> str:
     """Return the default module identifier.
 
     The value can be overridden via the ``DNDCS_DEFAULT_MODULE_ID`` environment
-    variable; otherwise the built-in ``fivee_stock`` module is used.
+    variable; otherwise the built-in ``fivee_stock`` module is used.  Empty
+    values are treated the same as if the variable was unset to avoid
+    returning an empty string when the environment variable is present but has
+    no content.
     """
-    return os.getenv("DNDCS_DEFAULT_MODULE_ID", "fivee_stock")
+    env_val = os.getenv("DNDCS_DEFAULT_MODULE_ID")
+    return env_val or "fivee_stock"

--- a/tests/test_registry_default_module_id.py
+++ b/tests/test_registry_default_module_id.py
@@ -1,0 +1,20 @@
+from dndcs.core import registry
+
+
+def test_default_module_id_env_var(monkeypatch):
+    # When env variable set to value, return that value
+    monkeypatch.setenv("DNDCS_DEFAULT_MODULE_ID", "custom_mod")
+    assert registry.default_module_id() == "custom_mod"
+
+
+def test_default_module_id_empty(monkeypatch):
+    # Empty environment variable should fall back to default
+    monkeypatch.setenv("DNDCS_DEFAULT_MODULE_ID", "")
+    assert registry.default_module_id() == "fivee_stock"
+
+
+def test_default_module_id_unset(monkeypatch):
+    # When environment variable not set at all, default is used
+    monkeypatch.delenv("DNDCS_DEFAULT_MODULE_ID", raising=False)
+    assert registry.default_module_id() == "fivee_stock"
+


### PR DESCRIPTION
## Summary
- treat empty `DNDCS_DEFAULT_MODULE_ID` env var as unset
- test default module resolution across env var states

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad755228588330be19aa7c3435e9a4