### PR TITLE
feat(ui): dynamic spell search for modules

### DIFF
--- a/src/dndcs/ui/static/app.js
+++ b/src/dndcs/ui/static/app.js
@@ -77,7 +77,10 @@
     return getJSON("/api/validate", { method: "POST", body: JSON.stringify(char) });
   }
   async function apiSpells(params={}) {
-    const q = new URLSearchParams(params);
+    const q = new URLSearchParams();
+    Object.entries(params).forEach(([k,v]) => {
+      if (v !== undefined && v !== null && v !== "") q.append(k, v);
+    });
     return getJSON(`/api/spells?${q.toString()}`);
   }
 
@@ -304,7 +307,7 @@
       if (!term) return;
       try {
         const cls = derived?.spellcasting?.class;
-        const res = await apiSpells({ name: term, class: cls });
+        const res = await apiSpells({ module: current?.module, name: term, cls });
         const dl = $("#spellSuggestions");
         dl.innerHTML = "";
         res.spells.slice(0, 20).forEach(sp => dl.append(el("option", { value: sp.name })));

--- a/tests/test_ui_spells.py
+++ b/tests/test_ui_spells.py
@@ -1,0 +1,17 @@
+import json
+from fastapi.testclient import TestClient
+from dndcs.ui.server import create_app
+
+
+def test_ui_spell_search_by_module():
+    app = create_app()
+    client = TestClient(app)
+    resp = client.get("/api/spells", params={"module": "fivee_stock", "name": "Aid"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert any(sp["name"] == "Aid" for sp in data.get("spells", []))
+    resp = client.get("/api/spells", params={"module": "fivee_stock", "cls": "wizard"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["spells"]
+    assert all("wizard" in sp.get("classes", []) for sp in data["spells"])


### PR DESCRIPTION
## Summary
- expose spell search endpoint that loads search functions from requested module
- pass module and class details from front-end when fetching spell suggestions
- add regression tests for spell search API

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad783cf678833097d1983351280bdd