### PR TITLE
Handle missing spellbook fields for character loading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
   "black>=24.4",
   "ruff>=0.5",
   "mypy>=1.10",
+  "httpx>=0.27",
 ]
 
 [project.scripts]

--- a/src/dndcs/ui/static/app.js
+++ b/src/dndcs/ui/static/app.js
@@ -98,6 +98,8 @@
     if (found) {
       found.props = found.props || {};
       found.props.spellbook = found.props.spellbook || { known:{}, prepared:{} };
+      found.props.spellbook.known = found.props.spellbook.known || {};
+      found.props.spellbook.prepared = found.props.spellbook.prepared || {};
       found.props.spellbook.known.cantrips = found.props.spellbook.known.cantrips || [];
       return found.props.spellbook;
     }


### PR DESCRIPTION
## Summary
- Prevent UI crash when spellbook lacks known/prepared sections by initializing them
- Include httpx in dev dependencies to satisfy FastAPI TestClient

## Testing
- `pip install -e .[dev,ui]`
- `pip install httpx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad7a31d8fc83309457a689ac481dde