### PR TITLE
Ensure spellbook spells render from inventory

### DIFF
--- a/tests/manual/spellbook_display.md
+++ b/tests/manual/spellbook_display.md
@@ -1,0 +1,10 @@
+# Spellbook Display Reproduction Steps
+
+1. Start the UI server:
+   ```
+   uvicorn dndcs.ui.server:app --port 8000
+   ```
+2. Open `http://localhost:8000` in a browser.
+3. Click **Open** and load `tests/data/wizard_l17.json`.
+4. The spellbook item from inventory is detected and the spells listed under the *Spells* tab appear immediately.
+5. Toggle a prepared spell checkbox or add a new known spell and observe that the **Raw** panel updates `current.items` to reflect the changes.


### PR DESCRIPTION
## Summary
- prevent renderSpells/ensureSpellbook from overwriting existing known/prepared arrays by fetching data with getSpellbook
- render spells after derive so inventory spellbooks show immediately
- document manual steps to verify spellbook rendering

## Testing
- `pytest tests/test_ui_spells.py::test_ui_spell_search_by_module tests/test_ui_character.py::test_ui_can_derive_level17_wizard -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad88577b708330b9fd1e2bf903f222